### PR TITLE
added optional flag specifications for each tool for flexibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@
 
 ## Description 
 
-Report summary statistics relating to quality of bam files with Nextflow. bamQC-nf is a Nextflow pipeline that runs the following tools using Singularity containers:
-* Samtools stats: detailed summary statistics for bam files
-* Mosdepth: fast bam depth calculations 
-* Qualimap bamqc: quality evaluation of bam files
+A flexible pipeline for reporting summary statistics relating to quality of bam files. bamQC-nf is a Nextflow (DSL2) pipeline that runs the following tools using Singularity containers:
+* Samtools stats: detailed summary statistics for bam files (default) 
+* Mosdepth: fast bam depth calculations (default)
+* Sambamba flagstats: high-level summary statistics for bam files (optional)
+* Qualimap bamqc: quality evaluation of bam files (optional)
 * MultiQC: cohort-level summary report of pipeline outputs (currently under development)
 
 ## Diagram
 
 <p align="center"> 
-<img src="https://user-images.githubusercontent.com/73086054/184803464-d3c5ef56-6d2f-4d27-b4e8-3d6786e3374d.png" width="80%">
+<img src="https://user-images.githubusercontent.com/73086054/187155487-0b85634a-0495-4aff-8813-259314bf67ab.png" width="80%">
 </p> 
 
 ## User guide
@@ -48,10 +49,10 @@ Samtools stats uses a reference genome to summarise the GC-depth and mismatches-
 
 #### 4. Run the pipeline
 
-To run the default pipeline, run the following command:   
+To run the default pipeline with Samtools stats and mosdepth, run the following command:   
 
 ```
-nextflow run main.nf --cohort <samples.tsv> --ref <ref.fasta> 
+nextflow run main.nf --cohort <samples.tsv> --ref <ref.fasta> --cpus <number of CPUs>
 ```
 
 Or run the following script after filling out the required input variables:  
@@ -60,7 +61,15 @@ Or run the following script after filling out the required input variables:
 bash run_bamqc.sh
 ```
 
+For improved flexibility and speed, users can specify which tools to run in addition to and instead of default options. For example, to run the pipeline with Samtools flagstat instead of Samtools stats, run the following:
+
+```
+nextflow run main.nf --cohort <samples.tsv> --ref <ref.fasta> --cpus <number of CPUs> --flagstat
+```
+
 While some parameters have default values in the workflow, you can adjust any of them in running your command. See the `nextflow.config` file to adjust the defaults, or add the following flags to your run command:
+* `--flagstat`: This runs sambamba flagstat instead of Samtools stats, for a faster runtime and less verbose metrics. 
+* `--qualimap`: This runs Qualimap's bamqc tool in addition to default tools. When coupled with `flagstat` will run Sambamba flagstat, Mosdepth, and Qualimap bamqc  
 * `--outDir`: This directory contains outputs for all samples processed with this pipeline. Currently set to `./bamQC_results`
 * `--runReports`: This directory contains all runtime summaries including resource usage and timelines. Currently set to `./bamQC_runInfo`
 
@@ -82,7 +91,7 @@ Coming soon!
 |-------------------|:---------------------------------:|
 |Version            | 1.0                               |
 |Maturity           | under development                 |
-|Creators           | Georgie Samaha, Nandan Deshpande  |
+|Creators           | Georgie Samaha, Cali Willet  |
 |Source             | NA                                |
 |License            | GPL-3.0 license                   |
 |Workflow manager   | Nextflow                          |

--- a/modules/sambambaFlagstat.nf
+++ b/modules/sambambaFlagstat.nf
@@ -1,0 +1,29 @@
+// Enable DSL-2 syntax
+nextflow.enable.dsl=2
+
+// Define the process
+process sambambaFlag {
+        cpus "${params.cpus}"
+        debug true
+        publishDir "${params.outDir}/${sampleID}", mode: 'copy'
+
+        // resource parameters. currently set to 4 CPUs
+        cpus "${params.cpus}"
+
+        // Run with sambamba v0.8.2 container
+        container "${params.sambamba__container}"
+
+        input:
+        tuple val(sampleID), file(bam)
+
+        output:
+        tuple val(sampleID), path("${sampleID}.sambamba.flagstats"), emit: sambamba_flagstats
+
+        script:
+        """
+        sambamba flagstat \
+        --nthreads ${params.cpus} \
+	--show-progress \
+        ${bam} > ${sampleID}.sambamba.flagstats
+        """
+}

--- a/modules/samtoolsStats.nf
+++ b/modules/samtoolsStats.nf
@@ -18,7 +18,6 @@ process samtoolsStats {
 
 	input:
 	tuple val(sampleID), file(bam)
-	file(ref)
 
 	output:
 	tuple val(sampleID), path("${sampleID}.samtools.stats"), emit: samtools_stats
@@ -26,7 +25,6 @@ process samtoolsStats {
 	script:
 	"""
 	samtools stats \
-        --reference ${params.ref} \
         --threads ${params.cpus} \
         ${bam} > ${sampleID}.samtools.stats
 	"""

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,15 +18,16 @@ manifest {
 // override the values defined here
   params.stats		= false
   params.flagstat	= false
+  params.qualimap	= false
+  params.mosdepth	= false
   params.ref		= false
   params.outDir		= './bamQC_results'
   params.cohort		= false
-  params.runReports	= './bamQC_runInfo'
   params.help		= false
     
 // Resource allocation 
 
-  params.cpus = 4 // all tools capable of multi-threading
+  params.cpus = 8 // all tools capable of multi-threading
 
 //  mem_samtoolsStats = '16 GB' // not yet allocated
 //  mem_qualimapBamqc = '16 GB' // not yet allocated
@@ -39,6 +40,7 @@ manifest {
         }
 
   params.samtools__container = 'docker://quay.io/biocontainers/samtools:1.15.1--h1170115_0'
+  params.sambamba__container = 'docker://quay.io/biocontainers/sambamba:0.8.2--h98b6b92_2' 
   params.mosdepth__container = 'docker://quay.io/biocontainers/mosdepth:0.3.1--ha7ba039_0'
   params.qualimap__container = 'docker://pegi3s/qualimap:2.2.1'
   params.multiqc__container = 'docker://quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' 


### PR DESCRIPTION
Running pipeline end to end with all tools is slow on large bams ~100GB. Default pipeline now runs mosdepth for depth calculations and samtools stats. Users can specify --qualimap for qualimap's bamqc (however this is slow) and/or --flagstat for sambamba flagstat. 

 